### PR TITLE
fix: correct incorrect formula for AC rating

### DIFF
--- a/posts/ko/stats/ac-rating.mdx
+++ b/posts/ko/stats/ac-rating.mdx
@@ -30,7 +30,7 @@ $$
 \begin{aligned}
 \left(\text{AC 레이팅}\right) &= \left(\text{해결한 난이도 상위 }100\text{문제의 난이도 값의 합}\right) \\
 &+  \left(\text{CLASS에 따른 보너스 레이팅}\right) \\
-&+  \left\lfloor 2000\times \left(1-0.997^{\left(\text{해결한 문제 수}\right)}\right) \right\rceil \\ 
+&+  \left\lfloor 200\times \left(1-0.997^{\left(\text{해결한 문제 수}\right)}\right) \right\rceil \\ 
 &+  \left\lfloor 25\times \left(1-0.9^{\left(\text{기여 수}\right)}\right) \right\rceil
 \end{aligned}
 $$


### PR DESCRIPTION
In this PR, I corrected the AC rating formula:

- Before

$$
\begin{aligned}
\left(\text{AC 레이팅}\right) &= \left(\text{해결한 난이도 상위 }100\text{문제의 난이도 값의 합}\right) \\
&+  \left(\text{CLASS에 따른 보너스 레이팅}\right) \\
&+  \left\lfloor 2000\times \left(1-0.997^{\left(\text{해결한 문제 수}\right)}\right) \right\rceil \\ 
&+  \left\lfloor 25\times \left(1-0.9^{\left(\text{기여 수}\right)}\right) \right\rceil
\end{aligned}
$$

- After

$$
\begin{aligned}
\left(\text{AC 레이팅}\right) &= \left(\text{해결한 난이도 상위 }100\text{문제의 난이도 값의 합}\right) \\
&+  \left(\text{CLASS에 따른 보너스 레이팅}\right) \\
&+  \left\lfloor 200\times \left(1-0.997^{\left(\text{해결한 문제 수}\right)}\right) \right\rceil \\ 
&+  \left\lfloor 25\times \left(1-0.9^{\left(\text{기여 수}\right)}\right) \right\rceil
\end{aligned}
$$